### PR TITLE
ingestor skips empty buffers

### DIFF
--- a/src/backend/tests/test_ingestor.py
+++ b/src/backend/tests/test_ingestor.py
@@ -36,9 +36,17 @@ def test_get_parameters(sample_buffer):
     assert parameters['metas'][0]['source'] == "doc1.txt"
 
 
-def test_flush_buffer(collection, sample_buffer):
+def test_flush_buffer_full(collection, sample_buffer):
     i = Ingestor()
     i.buffer = sample_buffer
     assert len(i.buffer) == 90
     i.flush_buffer(collection)
     assert len(i.buffer) == 0
+
+
+def test_flush_buffer_empty(collection):
+    i = Ingestor()
+    try:
+        i.flush_buffer(collection)
+    except ValueError:
+        pytest.fail("ValueError should not be thrown for an empty buffer.")

--- a/src/backend/vectorize/ingestor.py
+++ b/src/backend/vectorize/ingestor.py
@@ -27,9 +27,10 @@ class Ingestor:
         return parameters
 
     def flush_buffer(self, collection):
-        parameters = self.get_parameters()
-        self.batch_insert(collection, parameters)
-        self.buffer = []
+        if len(self.buffer) > 0:
+            parameters = self.get_parameters()
+            self.batch_insert(collection, parameters)
+            self.buffer = []
 
     def batch_insert(self, collection, parameters):
         collection.add(


### PR DESCRIPTION
- fixed the edge case where the vectorizer calls the ingestor to flush its buffer when the buffer is empty 