### PR TITLE
html processor deals in directories

### DIFF
--- a/src/backend/vectorize/process_html.py
+++ b/src/backend/vectorize/process_html.py
@@ -2,6 +2,7 @@ import argparse
 import json
 import logging
 from bs4 import BeautifulSoup  # type: ignore
+import os
 
 logger = logging.getLogger(__name__)
 
@@ -142,9 +143,12 @@ class HTMLProcessor():
 
     def process_files(self):
         logger.info("Processing html files.")
-        for path in self.config['input_paths']:
+        dir_path = self.config['input_directory']
+        for filename in os.listdir(dir_path):
+            path = os.path.join(dir_path, filename)
             source = self.get_source_title(path)
             self.process_html_file(path, source)
+
         logger.info("Finished processing html files.")
 
 


### PR DESCRIPTION
- changed the processing config design to have an attribute ``input-directory`` that points to you guessed it, the directory where all of the html files (input) are found
  - the previous design of manually tracking the path for each file to process was quite shortsided as it became intractable very fast - chunker config is soon to follow